### PR TITLE
Support NodeJS by adding `exports` key to `package.json`

### DIFF
--- a/build.js
+++ b/build.js
@@ -107,6 +107,21 @@ await build({
   ...sharedConfig
 });
 
+// CommonJS
+await build({
+  entryPoints: {'main': 'builds/module.ts'},
+  bundle: true,
+  external: [...Object.keys({ ...pkg.dependencies, ...pkg.peerDependencies }).filter(
+    // We only want to include tailwindcss as an external dependency for its types.
+    (name) => name !== 'tailwindcss',
+  ), ...externalDependenciesHack],
+  logLevel: 'info',
+  outdir: 'dist',
+  sourcemap: true,
+  format: 'cjs',
+  ...sharedConfig
+});
+
 // CDN
 await build({
   entryPoints: {'cdn.min': 'builds/cdn.js'},

--- a/build.js
+++ b/build.js
@@ -93,7 +93,7 @@ const externalDependenciesHack = ['@tailwindcss/oxide'];
 }
 
 // MODULE
-build({
+await build({
   entryPoints: {'module.esm': 'builds/module.ts'},
   bundle: true,
   external: [...Object.keys({ ...pkg.dependencies, ...pkg.peerDependencies }).filter(
@@ -108,7 +108,7 @@ build({
 });
 
 // CDN
-build({
+await build({
   entryPoints: {'cdn.min': 'builds/cdn.js'},
   external: externalDependenciesHack,
   bundle: true,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "dist/module.esm.js",
   "unpkg": "dist/cdn.min.js",
   "main": "dist/main.js",
+  "types": "index.d.ts",
   "files": [
     "index.d.ts",
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "exports": "./dist/module.esm.js",
   "module": "dist/module.esm.js",
   "unpkg": "dist/cdn.min.js",
+  "main": "dist/main.js",
   "files": [
     "index.d.ts",
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
     "examples/*",
     "tests/*"
   ],
-  "exports": "./dist/module.esm.js",
+  "exports": {
+    ".": {
+      "default": "./dist/module.esm.js",
+      "types": "./index.d.ts"
+    }
+  },
   "module": "dist/module.esm.js",
   "unpkg": "dist/cdn.min.js",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "examples/*",
     "tests/*"
   ],
+  "exports": "./dist/module.esm.js",
   "module": "dist/module.esm.js",
   "unpkg": "dist/cdn.min.js",
   "files": [


### PR DESCRIPTION
Currently, trying to import `@mhsdesign/jit-browser/tailwindcss` from a NodeJS project using ES Modules leads to a pretty cryptic error:

```
node:internal/modules/esm/resolve:213
  const resolvedOption = FSLegacyMainResolve(packageJsonUrlString, packageConfig.main, baseStringified);
                         ^

Error: Cannot find package '/some/project/node_modules/@mhsdesign/jit-browser-tailwindcss/package.json' imported from /some/project/index.mjs
```

I did some reading and found out this is because the `package.json` file doesn't list a NodeJS [package entry point](https://nodejs.org/api/packages.html#package-entry-points). Node either expects there to be a `"main"` field or `"exports"` field in `package.json`. Lots of packages have a `"module"` field, but Node doesn't use this (most bundlers support it though).

This PR adds the `"exports"` field to `package.json`, which is roughly equivalent to the `"module"` field, but is used by NodeJS.