### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "tests/*"
   ],
   "module": "dist/module.esm.js",
+  "main": "dist/module.esm.js",
   "unpkg": "dist/cdn.min.js",
   "files": [
     "index.d.ts",


### PR DESCRIPTION
First up, a HUGE thank you for putting this project out. I've just integrated it into a big project of mine and it worked perfectly on the first run. I had previously been using a hack with patch-package, and was stuck on Tailwind 3.1. I'm very impressed that you were able to figure this out, given the official way of running tw in the browser is not open source.

Without this small change to package.json I get errors running tests (with vitest) after adding jit-browser-tailwindcss to my project. I'm not a big expert on the insane world of JavaScript modules, so maybe you'll tell me there's a reason this "main" config should not be there. I honestly have no idea!