### PR TITLE
FEATURE: Expose `getClassOrder` from Tailwind

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,17 @@ export interface Tailwindcss {
    *   [myHtmlCode]
    * )
    */
-  generateStylesFromContent: (css: string, content: (Content | string)[]) => Promise<string>;
+  generateStylesFromContent: (css: string, content: (Content | string)[]) => Promise<string>
+
+  /**
+   * Get the class order for the provided list of classes
+   *
+   * @param classList The list of classes to get the order for.
+   * @returns The ordered list of classes.
+   * @example
+   * tailwindcss.getClassOrder(['left-3', 'inset-x-2', bg-red-500', 'bg-blue-500'])
+   */
+  getClassOrder: (classList: string[]) => string[]
 }
 
 /**
@@ -89,7 +99,7 @@ export interface Content {
 
 /**
  * Client side api to generate css via tailwind jit in the browser
- * 
+ *
  * @deprecated with 0.2.0
  */
 declare function jitBrowserTailwindcss(tailwindMainCss: string, jitContent: string, userTailwindConfig?: TailwindConfig): Promise<string>;

--- a/tests/unit-tests/src/getClassOrder.test.js
+++ b/tests/unit-tests/src/getClassOrder.test.js
@@ -1,0 +1,36 @@
+import { createTailwindcss } from '../../../dist/module.esm'
+
+test('getClassOrder', async () => {
+  const tailwind = createTailwindcss({
+    tailwindConfig: {
+      corePlugins: { preflight: false },
+    },
+  })
+
+  const cases = [
+    {
+      input: 'px-3 b-class p-1 py-3 bg-blue-500 a-class bg-red-500',
+      output: 'b-class a-class bg-blue-500 bg-red-500 p-1 px-3 py-3',
+    },
+    {
+      input: 'a-class px-3 p-1 b-class py-3 bg-red-500 bg-blue-500',
+      output: 'a-class b-class bg-blue-500 bg-red-500 p-1 px-3 py-3',
+    },
+    {
+      input: 'left-5 left-1',
+      output: 'left-1 left-5',
+    },
+    {
+      input: 'left-3 inset-x-10',
+      output: 'inset-x-10 left-3',
+    },
+    {
+      input: 'left-3 inset-x-2 bg-red-500 bg-blue-500',
+      output: 'inset-x-2 left-3 bg-blue-500 bg-red-500',
+    },
+  ]
+
+  for (const { input, output } of cases) {
+    expect(tailwind.getClassOrder(input.split(' '))).toEqual(output.split(' '))
+  }
+})

--- a/types.d.ts
+++ b/types.d.ts
@@ -55,6 +55,7 @@ declare module 'tailwindcss/src/lib/setupContextUtils.js' {
   export interface JitContext {
     changedContent: ChangedContent[];
     getClassList: () => string[];
+    getClassOrder: (classList: string[]) => Array<[string, bigint | null]>;
     tailwindConfig: TailwindConfig;
     variantMap: Map<VariantName, VariantFn[]>;
   }
@@ -89,3 +90,4 @@ declare module 'tailwindcss/src/public/resolve-config.js' {
 
   export default function resolveConfig(tailwindConfig: TailwindConfig): TailwindConfig;
 }
+


### PR DESCRIPTION
Resolves: https://github.com/mhsdesign/jit-browser-tailwindcss/issues/24

This PR exposes the `getClassOrder` function from Tailwind, and adds a test suite to showcase how it can be used.

`getClassOrder` can be used to implement functionality in the browser that's similar to what https://github.com/tailwindlabs/prettier-plugin-tailwindcss does. The concrete use cases for this could be
- Sorting tailwind classes in a text editor that's running in the browser
- Finding out what CSS properties and values will be applied to a given element. Sorting is relevant here, because if an element has conflicting props (for example `left-1 inset-x-2`, where `left-1` set the `left` property, and `inset-x` sets both `left` and `right`), we need to know in what order Tailwind will apply these classes to which TW class takes effect.

